### PR TITLE
feat: アセットのダイジェスト検証機能を追加

### DIFF
--- a/ElitesRNGAuraObserver.Updater/Core/ReleaseInfo.cs
+++ b/ElitesRNGAuraObserver.Updater/Core/ReleaseInfo.cs
@@ -5,7 +5,8 @@ namespace ElitesRNGAuraObserver.Updater.Core;
 /// </summary>
 /// <param name="tagName">タグ名</param>
 /// <param name="assetUrl">アセット URL</param>
-internal class ReleaseInfo(string tagName, string assetUrl)
+/// <param name="assetDigest">アセットのダイジェスト</param>
+internal class ReleaseInfo(string tagName, string assetUrl, string assetDigest)
 {
     /// <summary>
     /// リリースのタグ名
@@ -16,4 +17,10 @@ internal class ReleaseInfo(string tagName, string assetUrl)
     /// アセットのURL
     /// </summary>
     public string AssetUrl { get; } = assetUrl;
+
+    /// <summary>
+    /// アセットのダイジェスト
+    /// </summary>
+    /// <example>sha256:617d6861ded8113abbdb00d0e2ae0318fec957d53a9c9b40f33ac9b800ae54b6</example>
+    public string AssetDigest { get; } = assetDigest;
 }

--- a/ElitesRNGAuraObserver.Updater/Core/UpdaterHelper.cs
+++ b/ElitesRNGAuraObserver.Updater/Core/UpdaterHelper.cs
@@ -75,4 +75,29 @@ internal static class UpdaterHelper
             entry.ExtractToFile(fullPath, overwrite: true);
         }
     }
+
+    /// <summary>
+    /// Digestを検証する
+    /// </summary>
+    /// <param name="filePath">検証するファイルのパス</param>
+    /// <param name="expectedDigest">期待されるダイジェスト</param>
+    /// <returns>検証に成功した場合はtrue、失敗した場合はfalse</returns>
+    public static bool VerifyDigest(string filePath, string expectedDigest)
+    {
+        if (string.IsNullOrEmpty(expectedDigest))
+        {
+            throw new ArgumentException("Expected digest cannot be null or empty.", nameof(expectedDigest));
+        }
+
+        if (!File.Exists(filePath))
+        {
+            throw new FileNotFoundException($"File not found: {filePath}");
+        }
+
+        using var sha256 = System.Security.Cryptography.SHA256.Create();
+        using FileStream stream = File.OpenRead(filePath);
+        var hash = sha256.ComputeHash(stream);
+        var actualDigest = $"sha256:{Convert.ToHexStringLower(hash)}";
+        return string.Equals(actualDigest, expectedDigest, StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/ElitesRNGAuraObserver.Updater/Program.cs
+++ b/ElitesRNGAuraObserver.Updater/Program.cs
@@ -84,6 +84,13 @@ internal class Program
             var userAgent = $"{repoOwner} {repoName} ({AppConstants.AppVersionString})";
             var zipPath = await gh.DownloadWithProgressAsync(latest.AssetUrl).ConfigureAwait(false);
 
+            // ダウンロードしたファイルのチェックサム検証
+            Console.WriteLine("Verifying checksum...");
+            if (!UpdaterHelper.VerifyDigest(zipPath, latest.AssetDigest))
+            {
+                throw new InvalidOperationException("Checksum verification failed. The downloaded file may be corrupted.");
+            }
+
             // アプリ停止
             Console.WriteLine("Stopping running processes...");
             UpdaterHelper.KillProcesses(appName);


### PR DESCRIPTION
- close #60 

`GitHubReleaseService` クラスでアセットの URL とダイジェスト取得方法を改善し、例外処理を強化しました。`ReleaseInfo` クラスにダイジェストプロパティを追加し、整合性確認が可能に。`UpdaterHelper` クラスにファイルのダイジェストを検証する `VerifyDigest` メソッドを実装し、`Program` クラスでダウンロードファイルのチェックサム検証を追加しました。